### PR TITLE
feat: add feed like toggle endpoints

### DIFF
--- a/src/main/java/com/example/demo/src/feed/FeedLikeRepository.java
+++ b/src/main/java/com/example/demo/src/feed/FeedLikeRepository.java
@@ -1,8 +1,0 @@
-package com.example.demo.src.feed;
-
-import com.example.demo.src.feed.entity.FeedLike;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
-    long countByFeedId(Long feedId);
-}

--- a/src/main/java/com/example/demo/src/feed/FeedService.java
+++ b/src/main/java/com/example/demo/src/feed/FeedService.java
@@ -11,6 +11,7 @@ import com.example.demo.src.feed.model.PostFeedReq;
 import com.example.demo.src.user.UserRepository;
 import com.example.demo.src.user.entity.User;
 import com.example.demo.src.feed.entity.FeedImage;
+import com.example.demo.src.like.LikeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -31,7 +32,7 @@ public class FeedService {
     private final FeedRepository feedRepository;
     private final UserRepository userRepository;
     private final FeedImageRepository feedImageRepository;
-    private final FeedLikeRepository feedLikeRepository;
+    private final LikeRepository likeRepository;
 
     @Transactional(readOnly = true)
     public List<GetFeedRes> getFeeds(int pageIndex, int size) {
@@ -48,7 +49,7 @@ public class FeedService {
                             .stream()
                             .map(FeedImage::getImageUrl)
                             .collect(Collectors.toList());
-                    Long likeCount = feedLikeRepository.countByFeedId(f.getId());
+                    Long likeCount = likeRepository.countByFeedId(f.getId());
                     return new GetFeedRes(f.getId(), f.getUser().getId(), f.getContent(), f.getCreatedAt(), profile, imageUrls, likeCount);
                 })
                 .collect(Collectors.toList());
@@ -67,7 +68,7 @@ public class FeedService {
                 .stream()
                 .map(FeedImage::getImageUrl)
                 .collect(Collectors.toList());
-        Long likeCount = feedLikeRepository.countByFeedId(feed.getId());
+        Long likeCount = likeRepository.countByFeedId(feed.getId());
         return new GetFeedRes(feed.getId(), feed.getUser().getId(), feed.getContent(), feed.getCreatedAt(), profile, imageUrls, likeCount);
     }
 

--- a/src/main/java/com/example/demo/src/like/LikeController.java
+++ b/src/main/java/com/example/demo/src/like/LikeController.java
@@ -1,0 +1,34 @@
+package com.example.demo.src.like;
+
+import com.example.demo.common.response.BaseResponse;
+import com.example.demo.utils.JwtService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "like", description = "좋아요 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/app/feeds")
+public class LikeController {
+
+    private final LikeService likeService;
+    private final JwtService jwtService;
+
+    @Operation(summary = "좋아요 토글", description = "좋아요를 추가하거나 취소합니다.")
+    @PostMapping("/{feedId}/like")
+    public BaseResponse<Long> toggleLike(@PathVariable Long feedId) {
+        Long userId = jwtService.getUserId();
+        Long count = likeService.toggleLike(feedId, userId);
+        return new BaseResponse<>(count);
+    }
+
+    @Operation(summary = "좋아요 취소", description = "좋아요를 취소합니다.")
+    @DeleteMapping("/{feedId}/like")
+    public BaseResponse<Long> cancelLike(@PathVariable Long feedId) {
+        Long userId = jwtService.getUserId();
+        Long count = likeService.cancelLike(feedId, userId);
+        return new BaseResponse<>(count);
+    }
+}

--- a/src/main/java/com/example/demo/src/like/LikeRepository.java
+++ b/src/main/java/com/example/demo/src/like/LikeRepository.java
@@ -1,0 +1,13 @@
+package com.example.demo.src.like;
+
+import com.example.demo.src.like.entity.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+    long countByFeedId(Long feedId);
+    boolean existsByFeedIdAndUserId(Long feedId, Long userId);
+    void deleteByFeedIdAndUserId(Long feedId, Long userId);
+    Optional<Like> findByFeedIdAndUserId(Long feedId, Long userId);
+}

--- a/src/main/java/com/example/demo/src/like/LikeService.java
+++ b/src/main/java/com/example/demo/src/like/LikeService.java
@@ -1,0 +1,47 @@
+package com.example.demo.src.like;
+
+import com.example.demo.common.exceptions.BaseException;
+import com.example.demo.src.feed.FeedRepository;
+import com.example.demo.src.feed.entity.Feed;
+import com.example.demo.src.feed.entity.FeedStatus;
+import com.example.demo.src.like.entity.Like;
+import com.example.demo.src.user.UserRepository;
+import com.example.demo.src.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.demo.common.response.BaseResponseStatus.NOT_FIND_FEED;
+import static com.example.demo.common.response.BaseResponseStatus.NOT_FIND_USER;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+    private final FeedRepository feedRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Long toggleLike(Long feedId, Long userId) {
+        if (likeRepository.existsByFeedIdAndUserId(feedId, userId)) {
+            likeRepository.deleteByFeedIdAndUserId(feedId, userId);
+        } else {
+            Feed feed = feedRepository.findById(feedId)
+                    .orElseThrow(() -> new BaseException(NOT_FIND_FEED));
+            if (feed.getStatus() != FeedStatus.ACTIVE) throw new BaseException(NOT_FIND_FEED);
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new BaseException(NOT_FIND_USER));
+            likeRepository.save(Like.builder().feed(feed).user(user).build());
+        }
+        return likeRepository.countByFeedId(feedId);
+    }
+
+    @Transactional
+    public Long cancelLike(Long feedId, Long userId) {
+        if (likeRepository.existsByFeedIdAndUserId(feedId, userId)) {
+            likeRepository.deleteByFeedIdAndUserId(feedId, userId);
+        }
+        return likeRepository.countByFeedId(feedId);
+    }
+}

--- a/src/main/java/com/example/demo/src/like/entity/Like.java
+++ b/src/main/java/com/example/demo/src/like/entity/Like.java
@@ -1,5 +1,6 @@
-package com.example.demo.src.feed.entity;
+package com.example.demo.src.like.entity;
 
+import com.example.demo.src.feed.entity.Feed;
 import com.example.demo.src.user.entity.User;
 import lombok.*;
 
@@ -10,7 +11,7 @@ import javax.persistence.*;
 @Getter
 @Entity
 @Table(name = "feed_likes")
-public class FeedLike {
+public class Like {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "feed_like_id", nullable = false, updatable = false)
@@ -25,7 +26,7 @@ public class FeedLike {
     private User user;
 
     @Builder
-    public FeedLike(Long id, Feed feed, User user) {
+    public Like(Long id, Feed feed, User user) {
         this.id = id;
         this.feed = feed;
         this.user = user;


### PR DESCRIPTION
## Summary
- add like entity, repository, service, controller
- enable toggling feed likes via POST `/app/feeds/{feedId}/like` and cancellation with DELETE
- expose like counts through feed service

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b14cf6d7e0832ebb83c4d70398ba37